### PR TITLE
fix up tests

### DIFF
--- a/hook.scm
+++ b/hook.scm
@@ -10,14 +10,14 @@
 
   (import (scheme base))
 
-  (import (srfi srfi-145))
+  (import (srfi 145))
 
   (begin
 
     (define-record-type <hook>
       (%make-hook procs arity)
       hook?
-      (proc hook-procs hook-procs!)
+      (procs hook-procs hook-procs!)
       (arity hook-arity hook-arity!))
 
     (define (make-hook arity)

--- a/tests-gauche.scm
+++ b/tests-gauche.scm
@@ -1,0 +1,3 @@
+(import (scheme base) (compat chibi-test) (hook))
+(chibi-test
+ (include "tests.scm"))

--- a/tests.scm
+++ b/tests.scm
@@ -1,5 +1,4 @@
-(import (chibi test))
-
+(import (scheme base) (chibi test) (hook))
 
 ;; test hook->list and make-hook
 (test 0 (length (hook->list (make-hook 0))))
@@ -33,5 +32,6 @@
           (let ((increment (lambda () (set! counter (+ counter 1))))
                 (decrement (lambda () (set! counter (- counter 1)))))
             (hook-add! hook increment)
+            (hook-add! hook decrement)
             (hook-run hook)
             counter)))


### PR DESCRIPTION
add a test wrapper to run the tests on Gauche. I think the test hook-run
fixup is correct since zero is the expected result of _not_ running the
hook.

Chibi also fails this test, but it's a bit harder to see the litte red
'x' (I missed it the first time, and thought something broke subtly on
Gauche)