### PR TITLE
Use direct (include ...) in R7RS library

### DIFF
--- a/hook.sld
+++ b/hook.sld
@@ -14,6 +14,4 @@
 
   (import (srfi 145))
 
-  (begin
-
-    (include "hook.body.scm")))
+  (include "hook.body.scm"))


### PR DESCRIPTION
In Chibi-Scheme, an (include) inside (begin) uses different pathname lookup rules than without (begin).